### PR TITLE
Find and set the nearest `.scss-lint.yml` config file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,11 @@
         "test": "node ./node_modules/vscode/bin/test"
     },
     "devDependencies": {
-        "typescript": "^2.0.3",
-        "vscode": "^1.0.0",
-        "mocha": "^2.3.3",
+        "@types/mocha": "^2.2.32",
         "@types/node": "^6.0.40",
-        "@types/mocha": "^2.2.32"
+        "find-parent-dir": "^0.3.0",
+        "mocha": "^2.3.3",
+        "typescript": "^2.0.3",
+        "vscode": "^1.0.0"
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import {
 
 let exec = require('child_process').exec;
 let backgroundColor = 'rgba(200, 0, 0, .8)';
+let findParentDir = require('find-parent-dir');
 
 const errorDecorationType = window.createTextEditorDecorationType({
     backgroundColor,
@@ -60,7 +61,16 @@ class ErrorFinder {
         if (doc.languageId === "scss") {
             const dir = (workspace.rootPath || '') + '/';
             const fileName = doc.fileName.replace(dir, '');
-            const cmd = `cd ${dir} && scss-lint --no-color ${fileName}`;
+            let cmd = `cd ${dir} && scss-lint --config --no-color ${fileName}`;
+
+            // Find and set nearest config file
+            try {
+                const configDir =  doc.fileName.substring(0,  doc.fileName.lastIndexOf('/'));
+                const configFileDir = findParentDir.sync(configDir, '.scss-lint.yml');
+                cmd = `cd ${dir} && scss-lint -c ${configFileDir + '.scss-lint.yml'} --no-color ${fileName}`;
+            } catch(err) {
+                console.error('error', err); 
+            }
 
             exec(cmd, (err, stdout) => {
                 const activeEditor = window.activeTextEditor;


### PR DESCRIPTION
Searches the active file's directory and parent directories for a config file to use. If found, updates the `cmd` variable to specify the location of the config file.